### PR TITLE
length-weighted W

### DIFF
--- a/inequality/util.py
+++ b/inequality/util.py
@@ -2,7 +2,7 @@
 Useful functions for segregation metrics
 """
 
-__author__ = "Levi Wolf <levi.john.wolf@bristol.ac.uk> and Renan X. Cortes <renanc@ucr.edu>"
+__author__ = "Levi Wolf <levi.john.wolf@gmail.com> and Renan X. Cortes <renanc@ucr.edu>"
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
This has quite a bit of streamlining/clean up from the explanatory version I posted in the notebook for @renanxcortes 

noting a few changes:
1. we should use rook weights as the source if you're doing perimeter-weighted stuff. A shared perimeter of a point will have zero length weight. 
2. we shouldn't force the index into a column. Merge can take care of this using the `right_index` and `left_index` constructs. 
3. the `geometry` column in a geopandas geodataframe is a special thing, it's not just a regular column. it's got metadata, stored in `_geometry_column_name`, that tells us what its `name` is as a series. (like, if we do `df.geometry.name`, that doesn't *have* to be "geometry", and our code shouldn't assume this). 
4. The adjlist shouldn't contain islands, so I think the best way to do this is to handle this specific thing in this function. Basically, what we're doing is adding self-loops of zero weight, then going back through and deleting the self-loops. 